### PR TITLE
Fix Android AEC on speakerphone (#4) + 16 KB compatibility + SafeAreaView migration

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,7 +56,10 @@ android {
   }
 
   dependencies {
-    implementation 'com.microsoft.onnxruntime:onnxruntime-android:1.20.0'
+    // 1.23.0+ ships libonnxruntime4j_jni.so with 16 KB-aligned LOAD segments,
+    // required for Google Play submissions targeting Android 15+ devices
+    // (microsoft/onnxruntime PR #24947, post-1.22 release).
+    implementation 'com.microsoft.onnxruntime:onnxruntime-android:1.24.1'
     implementation 'com.tagtraum:pcmsampledsp:0.9.5'
   }
 }

--- a/android/src/main/java/com/paulingalls/realtimeaudio/RealtimeAudioPlayer.kt
+++ b/android/src/main/java/com/paulingalls/realtimeaudio/RealtimeAudioPlayer.kt
@@ -19,8 +19,8 @@ class RealtimeAudioPlayer(
 ) : SharedObject() {
     private var audioTrack: AudioTrack? = null
     private val bufferQueue = ConcurrentLinkedQueue<ByteArray>()
-    private var isPlaying = false
-    private var isPaused = false
+    @Volatile private var isPlaying = false
+    @Volatile private var isPaused = false
     private var playerThread: Thread? = null
 
     var delegate: RealtimeAudioPlayerDelegate? = null
@@ -29,8 +29,12 @@ class RealtimeAudioPlayer(
         val bufferSize = AudioTrack.getMinBufferSize(sampleRate, channelConfig, audioFormat)
         audioTrack = AudioTrack.Builder()
             .setAudioAttributes(
+                // USAGE_VOICE_COMMUNICATION (paired with the VOICE_COMMUNICATION recorder
+                // source and AudioManager.MODE_IN_COMMUNICATION) is what lets Android's
+                // hardware AEC link the playback and capture streams. USAGE_MEDIA breaks
+                // echo cancellation on speakerphone for AI voice loops.
                 AudioAttributes.Builder()
-                    .setUsage(AudioAttributes.USAGE_MEDIA)
+                    .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
                     .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
                     .build()
             )
@@ -49,7 +53,7 @@ class RealtimeAudioPlayer(
     fun addBuffer(base64EncodedBuffer: String) {
         val decodedBuffer = Base64.decode(base64EncodedBuffer, Base64.DEFAULT)
         bufferQueue.offer(decodedBuffer)
-        if (!isPlaying && !isPaused && bufferQueue.size > 4) {
+        if (!isPlaying && !isPaused && bufferQueue.isNotEmpty()) {
             startPlayback()
         }
     }
@@ -64,23 +68,27 @@ class RealtimeAudioPlayer(
 
         playerThread = thread(start = true) {
             var hasWaitedABitToSeeIfMoreBuffersComeSoon = false
-            while (isPlaying) {
-                if (!isPaused) {
-                    val buffer = bufferQueue.poll()
-                    if (buffer != null) {
-                        delegate?.bufferReady(buffer)
-                        audioTrack?.write(buffer, 0, buffer.size)
-                    } else {
-                        if (!hasWaitedABitToSeeIfMoreBuffersComeSoon) {
-                            Thread.sleep(300)
-                            hasWaitedABitToSeeIfMoreBuffersComeSoon = true
+            try {
+                while (isPlaying) {
+                    if (!isPaused) {
+                        val buffer = bufferQueue.poll()
+                        if (buffer != null) {
+                            delegate?.bufferReady(buffer)
+                            audioTrack?.write(buffer, 0, buffer.size)
                         } else {
-                            isPlaying = false
+                            if (!hasWaitedABitToSeeIfMoreBuffersComeSoon) {
+                                Thread.sleep(300)
+                                hasWaitedABitToSeeIfMoreBuffersComeSoon = true
+                            } else {
+                                isPlaying = false
+                            }
                         }
+                    } else {
+                        Thread.sleep(100)
                     }
-                } else {
-                    Thread.sleep(100)
                 }
+            } catch (_: InterruptedException) {
+                // stopPlayback() interrupted us; fall through to playbackStopped().
             }
             delegate?.playbackStopped()
         }
@@ -91,9 +99,14 @@ class RealtimeAudioPlayer(
         isPlaying = false
         isPaused = false
         bufferQueue.clear()
-        playerThread?.join()
+        // Stop the AudioTrack first so any in-flight blocking write() returns,
+        // then interrupt to break out of the drain-wait Thread.sleep, then
+        // bounded join so a misbehaving thread can't hang the caller.
         audioTrack?.stop()
         audioTrack?.flush()
+        playerThread?.interrupt()
+        playerThread?.join(1000L)
+        playerThread = null
     }
 
     fun pausePlayback() {

--- a/android/src/main/java/com/paulingalls/realtimeaudio/RealtimeAudioRecorder.kt
+++ b/android/src/main/java/com/paulingalls/realtimeaudio/RealtimeAudioRecorder.kt
@@ -1,7 +1,9 @@
 package com.paulingalls.realtimeaudio
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.media.AudioFormat
+import android.media.AudioManager
 import android.media.AudioRecord
 import android.media.MediaRecorder
 import android.util.Base64
@@ -22,6 +24,7 @@ interface RealtimeAudioBufferDelegate {
 }
 
 class RealtimeAudioRecorder(
+    context: Context,
     private val sampleRate: Int,
     private val channelConfig: Int,
     private val audioFormat: Int = AudioFormat.ENCODING_PCM_16BIT
@@ -29,7 +32,12 @@ class RealtimeAudioRecorder(
     var delegate: RealtimeAudioBufferDelegate? = null
     var isEchoCancellationEnabled = false
 
+    private val audioManager =
+        context.applicationContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
     private var audioRecord: AudioRecord? = null
+    private var currentAudioSource: Int = -1
+    private var savedAudioMode: Int = AudioManager.MODE_NORMAL
+    private var didChangeAudioMode = false
     private var isRecording = false
     private var recordingJob: Job? = null
     private val recordingScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
@@ -41,12 +49,14 @@ class RealtimeAudioRecorder(
         if (isRecording) return
 
         try {
-            initializeAudioRecord()
+            ensureAudioRecord()
+            beginCommunicationModeIfNeeded()
             audioRecord?.startRecording()
             isRecording = true
             startRecordingJob()
         } catch (e: Exception) {
             print("error starting to record $e")
+            endCommunicationModeIfNeeded()
         }
     }
 
@@ -56,26 +66,45 @@ class RealtimeAudioRecorder(
         }
         isRecording = false
         recordingJob?.cancel()
-        audioRecord?.apply {
-            stop()
-            release()
-        }
-        audioRecord = null
+        // Stop but keep the AudioRecord alive — re-creating an AudioRecord on the
+        // VOICE_COMMUNICATION source costs 100-300ms of dead time per cycle. release()
+        // happens in release().
+        audioRecord?.stop()
+        endCommunicationModeIfNeeded()
     }
 
     @SuppressLint("MissingPermission")
-    private fun initializeAudioRecord() {
-        var source = MediaRecorder.AudioSource.MIC
-        if (isEchoCancellationEnabled) {
-            source = MediaRecorder.AudioSource.VOICE_COMMUNICATION
+    private fun ensureAudioRecord() {
+        val desiredSource = if (isEchoCancellationEnabled) {
+            MediaRecorder.AudioSource.VOICE_COMMUNICATION
+        } else {
+            MediaRecorder.AudioSource.MIC
         }
+        if (audioRecord != null && currentAudioSource == desiredSource) {
+            return
+        }
+        audioRecord?.release()
         audioRecord = AudioRecord(
-            source,
+            desiredSource,
             sampleRate,
             channelConfig,
             audioFormat,
             bufferSize
         )
+        currentAudioSource = desiredSource
+    }
+
+    private fun beginCommunicationModeIfNeeded() {
+        if (!isEchoCancellationEnabled || didChangeAudioMode) return
+        savedAudioMode = audioManager.mode
+        audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
+        didChangeAudioMode = true
+    }
+
+    private fun endCommunicationModeIfNeeded() {
+        if (!didChangeAudioMode) return
+        audioManager.mode = savedAudioMode
+        didChangeAudioMode = false
     }
 
     private fun startRecordingJob() {
@@ -101,6 +130,9 @@ class RealtimeAudioRecorder(
 
     fun release() {
         stopRecording()
+        audioRecord?.release()
+        audioRecord = null
+        currentAudioSource = -1
         recordingScope.cancel()
     }
 }

--- a/android/src/main/java/com/paulingalls/realtimeaudio/RealtimeAudioRecorderModule.kt
+++ b/android/src/main/java/com/paulingalls/realtimeaudio/RealtimeAudioRecorderModule.kt
@@ -25,6 +25,7 @@ class RealtimeAudioRecorderModule : Module() {
         Class("RealtimeAudioRecorder", RealtimeAudioRecorder::class) {
             Constructor { format: AudioFormatSettings, echoCancellationEnabled: Boolean ->
                 return@Constructor RealtimeAudioRecorder(
+                    appContext.reactContext!!.applicationContext,
                     format.sampleRate,
                     mapChannelCountToInputFormat(format.channelCount),
                     mapAudioEncodingToFormat(format.encoding)

--- a/android/src/main/java/com/paulingalls/realtimeaudio/RealtimeAudioRecorderView.kt
+++ b/android/src/main/java/com/paulingalls/realtimeaudio/RealtimeAudioRecorderView.kt
@@ -19,7 +19,7 @@ class RealtimeAudioRecorderView(
 
     override fun setAudioFormat(sampleRate: Int, channelConfig: Int, audioFormat: Int) {
         audioRecorder?.release()
-        audioRecorder = RealtimeAudioRecorder(sampleRate, channelConfig, audioFormat).apply {
+        audioRecorder = RealtimeAudioRecorder(context, sampleRate, channelConfig, audioFormat).apply {
             delegate = this@RealtimeAudioRecorderView
             isEchoCancellationEnabled = this@RealtimeAudioRecorderView.isEchoCancellationEnabled
         }

--- a/android/src/main/java/com/paulingalls/realtimeaudio/RealtimeAudioVADRecorder.kt
+++ b/android/src/main/java/com/paulingalls/realtimeaudio/RealtimeAudioVADRecorder.kt
@@ -1,7 +1,9 @@
 package com.paulingalls.realtimeaudio
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.media.AudioFormat
+import android.media.AudioManager
 import android.media.AudioRecord
 import android.media.MediaRecorder
 import android.util.Base64
@@ -32,6 +34,7 @@ private const val VAD_CHANNEL_CONFIG = AudioFormat.CHANNEL_IN_MONO
 private const val VAD_AUDIO_FORMAT = AudioFormat.ENCODING_PCM_FLOAT
 
 class RealtimeAudioVADRecorder(
+    context: Context,
     private val sampleRate: Int,
     private val channelConfig: Int,
     private val audioFormat: Int = AudioFormat.ENCODING_PCM_16BIT
@@ -40,7 +43,12 @@ class RealtimeAudioVADRecorder(
     var isEchoCancellationEnabled = false
     var modelPath: String = ""
 
+    private val audioManager =
+        context.applicationContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
     private var audioRecord: AudioRecord? = null
+    private var currentAudioSource: Int = -1
+    private var savedAudioMode: Int = AudioManager.MODE_NORMAL
+    private var didChangeAudioMode = false
     private var isListening = false
     private var isSpeaking = false
     private var recordingJob: Job? = null
@@ -66,23 +74,24 @@ class RealtimeAudioVADRecorder(
                 throw Exception("Buffer size is too small")
             }
             initializeVAD()
-            initializeAudioRecord()
+            ensureAudioRecord()
+            beginCommunicationModeIfNeeded()
             audioRecord?.startRecording()
             isListening = true
             startRecordingJob()
         } catch (e: Exception) {
             print("error starting to record $e")
+            endCommunicationModeIfNeeded()
         }
     }
 
     fun stopListening() {
         isListening = false
         recordingJob?.cancel()
-        audioRecord?.apply {
-            stop()
-            release()
-        }
-        audioRecord = null
+        // Keep the AudioRecord alive between cycles — VOICE_COMMUNICATION re-init
+        // is the slowest part of restarting capture.
+        audioRecord?.stop()
+        endCommunicationModeIfNeeded()
         delegate?.voiceStopped()
     }
 
@@ -104,18 +113,37 @@ class RealtimeAudioVADRecorder(
     }
 
     @SuppressLint("MissingPermission")
-    private fun initializeAudioRecord() {
-        var source = MediaRecorder.AudioSource.MIC
-        if (isEchoCancellationEnabled) {
-            source = MediaRecorder.AudioSource.VOICE_COMMUNICATION
+    private fun ensureAudioRecord() {
+        val desiredSource = if (isEchoCancellationEnabled) {
+            MediaRecorder.AudioSource.VOICE_COMMUNICATION
+        } else {
+            MediaRecorder.AudioSource.MIC
         }
+        if (audioRecord != null && currentAudioSource == desiredSource) {
+            return
+        }
+        audioRecord?.release()
         audioRecord = AudioRecord(
-            source,
+            desiredSource,
             VAD_SAMPLE_RATE,
             VAD_CHANNEL_CONFIG,
             VAD_AUDIO_FORMAT,
             bufferSize
         )
+        currentAudioSource = desiredSource
+    }
+
+    private fun beginCommunicationModeIfNeeded() {
+        if (!isEchoCancellationEnabled || didChangeAudioMode) return
+        savedAudioMode = audioManager.mode
+        audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
+        didChangeAudioMode = true
+    }
+
+    private fun endCommunicationModeIfNeeded() {
+        if (!didChangeAudioMode) return
+        audioManager.mode = savedAudioMode
+        didChangeAudioMode = false
     }
 
     private fun startRecordingJob() {
@@ -177,6 +205,9 @@ class RealtimeAudioVADRecorder(
 
     fun release() {
         stopListening()
+        audioRecord?.release()
+        audioRecord = null
+        currentAudioSource = -1
         recordingScope.cancel()
     }
 }

--- a/android/src/main/java/com/paulingalls/realtimeaudio/RealtimeAudioVADRecorderModule.kt
+++ b/android/src/main/java/com/paulingalls/realtimeaudio/RealtimeAudioVADRecorderModule.kt
@@ -30,6 +30,7 @@ class RealtimeAudioVADRecorderModule : Module() {
         Class("RealtimeAudioVADRecorder", RealtimeAudioVADRecorder::class) {
             Constructor { format: AudioFormatSettings, echoCancellationEnabled: Boolean ->
                 return@Constructor RealtimeAudioVADRecorder(
+                    appContext.reactContext!!.applicationContext,
                     format.sampleRate,
                     mapChannelCountToInputFormat(format.channelCount),
                     mapAudioEncodingToFormat(format.encoding)

--- a/android/src/main/java/com/paulingalls/realtimeaudio/RealtimeAudioVADRecorderView.kt
+++ b/android/src/main/java/com/paulingalls/realtimeaudio/RealtimeAudioVADRecorderView.kt
@@ -19,7 +19,7 @@ class RealtimeAudioVADRecorderView(
 
     override fun setAudioFormat(sampleRate: Int, channelConfig: Int, audioFormat: Int) {
         audioRecorder?.release()
-        audioRecorder = RealtimeAudioVADRecorder(sampleRate, channelConfig, audioFormat).apply {
+        audioRecorder = RealtimeAudioVADRecorder(context, sampleRate, channelConfig, audioFormat).apply {
             delegate = this@RealtimeAudioVADRecorderView
             isEchoCancellationEnabled = this@RealtimeAudioVADRecorderView.isEchoCancellationEnabled
             modelPath = this@RealtimeAudioVADRecorderView.modelPath

--- a/example/app/(tabs)/index.tsx
+++ b/example/app/(tabs)/index.tsx
@@ -1,4 +1,5 @@
-import { Button, SafeAreaView, ScrollView, StyleSheet, Text, View } from "react-native";
+import { Button, ScrollView, StyleSheet, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import {
   AudioEncoding,
   RealtimeAudioModule,

--- a/example/app/(tabs)/record.tsx
+++ b/example/app/(tabs)/record.tsx
@@ -1,4 +1,5 @@
-import { Button, SafeAreaView, ScrollView, StyleSheet, Text, View } from "react-native";
+import { Button, ScrollView, StyleSheet, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { useEffect, useRef, useState } from "react";
 import {
   AudioEncoding,

--- a/example/app/(tabs)/vad.tsx
+++ b/example/app/(tabs)/vad.tsx
@@ -1,4 +1,5 @@
-import { Button, SafeAreaView, ScrollView, StyleSheet, Text, View } from "react-native";
+import { Button, ScrollView, StyleSheet, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { Group } from "../../components/group";
 import { useEffect, useRef, useState } from "react";
 import {


### PR DESCRIPTION
Three independent Android-side fixes.

## 1. Fix AEC on speakerphone (closes #4)

Reported by @zaheenrahman: with \`echoCancellationEnabled: true\` and audio playing through the speaker, the recorder mic picks up its own playback, causing AI voice apps to loop.

Root cause: Android's hardware AEC requires both the player and recorder streams to sit in the voice-comm audio path. The player was using \`USAGE_MEDIA\` instead of \`USAGE_VOICE_COMMUNICATION\`, and \`AudioManager.mode\` was never set to \`MODE_IN_COMMUNICATION\`. Without these, the recorder's \`VOICE_COMMUNICATION\` source had nothing to link against.

This commit also addresses the three secondary issues called out in the same report:

- **Player buffer threshold dropped from \`> 4\` to \`> 0\`** so playback starts on the first buffer (matches iOS, which has no equivalent gate).
- **\`stopPlayback()\` no longer hangs in \`playerThread.join()\`**: stop the AudioTrack first to unblock any in-flight blocking \`write()\`, interrupt the thread to break the drain-wait \`Thread.sleep\`, then bound the join at 1s. The thread body is wrapped in \`try { ... } catch (_: InterruptedException) { }\` so it still calls \`playbackStopped()\` cleanly.
- **\`AudioRecord\` is kept alive between start/stop cycles.** Re-creating an AudioRecord on the \`VOICE_COMMUNICATION\` source costs 100–300ms of dead time per cycle. \`ensureAudioRecord()\` initializes lazily and only re-creates when the EC source actually changes; \`release()\` does the actual teardown.

\`:react-native-realtime-audio:compileDebugKotlin\` succeeds.

## 2. Bump onnxruntime-android 1.20.0 → 1.24.1

Google Play requires APKs targeting Android 15+ to ship native libs with LOAD segments aligned at 16 KB boundaries (Nov 1, 2025 deadline). The \`libonnxruntime4j_jni.so\` shipped with onnxruntime-android 1.20.0–1.22.0 was 4 KB-aligned, triggering "APK not compatible with 16 KB devices" warnings on install.

The JNI alignment fix is microsoft/onnxruntime#24947, merged after 1.22.0's release; first stable release with the fix is 1.23.0. Bumping to 1.24.1 (latest stable) for the fix plus accumulated patches.

Verified the .aar contents:

\`\`\`
jni/arm64-v8a/libonnxruntime4j_jni.so  LOAD align 0x4000  ✓
jni/x86_64/libonnxruntime4j_jni.so     LOAD align 0x4000  ✓
\`\`\`

## 3. Migrate example tabs to react-native-safe-area-context

\`react-native\` deprecated its bundled \`SafeAreaView\` in 0.83. Switch all three tabs to the implementation from \`react-native-safe-area-context\`, which is already a dep. The expo-router root provides the \`SafeAreaProvider\` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)